### PR TITLE
Introduces ConnectionBrokenDeterminer

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -190,6 +190,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     }
   }
 
+  public void setConnectionBrokenDeterminer(final ConnectionBrokenDeterminer determiner) {
+    client.setConnectionBrokenDeterminer(determiner);
+  }
+
   @Override
   public String ping() {
     checkIsInMultiOrPipeline();

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -37,6 +37,7 @@ public class Connection implements Closeable {
   private SSLSocketFactory sslSocketFactory;
   private SSLParameters sslParameters;
   private HostnameVerifier hostnameVerifier;
+  private ConnectionBrokenDeterminer connBrokenDeterminer = new ConnectionBrokenDeterminer();
 
   public Connection() {
   }
@@ -65,6 +66,10 @@ public class Connection implements Closeable {
     this.sslSocketFactory = sslSocketFactory;
     this.sslParameters = sslParameters;
     this.hostnameVerifier = hostnameVerifier;
+  }
+
+  public void setConnectionBrokenDeterminer(final ConnectionBrokenDeterminer determiner) {
+    this.connBrokenDeterminer = determiner;
   }
 
   public Socket getSocket() {
@@ -308,9 +313,13 @@ public class Connection implements Closeable {
   protected Object readProtocolWithCheckingBroken() {
     try {
       return Protocol.read(inputStream);
-    } catch (JedisConnectionException exc) {
-      broken = true;
-      throw exc;
+    } catch (RuntimeException e) {
+      if (connBrokenDeterminer.determine(e)) {
+        broken = true;
+        throw new JedisConnectionException(e);
+      } else {
+        throw e;
+      }
     }
   }
 

--- a/src/main/java/redis/clients/jedis/ConnectionBrokenDeterminer.java
+++ b/src/main/java/redis/clients/jedis/ConnectionBrokenDeterminer.java
@@ -1,0 +1,44 @@
+package redis.clients.jedis;
+
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConnectionBrokenDeterminer {
+  private List<ConnectionBrokenPattern> filters;
+
+  public ConnectionBrokenDeterminer() {
+    filters = new ArrayList<ConnectionBrokenPattern>();
+
+    // applies default filter
+    filters.add(new JedisConnectionExceptionAsConnectionBroken());
+  }
+
+  public void addPattern(final ConnectionBrokenPattern pattern) {
+    filters.add(pattern);
+  }
+
+  public boolean determine(final RuntimeException exc) {
+    for (ConnectionBrokenPattern filter : filters) {
+      if (filter.determine(exc)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Treats JedisConnectionException as broken connection
+   */
+  private static class JedisConnectionExceptionAsConnectionBroken
+      implements ConnectionBrokenPattern {
+    @Override public boolean determine(final RuntimeException exc) {
+      if (exc instanceof JedisConnectionException) {
+        return true;
+      }
+      return false;
+    }
+  }
+}

--- a/src/main/java/redis/clients/jedis/ConnectionBrokenPattern.java
+++ b/src/main/java/redis/clients/jedis/ConnectionBrokenPattern.java
@@ -1,0 +1,5 @@
+package redis.clients.jedis;
+
+public interface ConnectionBrokenPattern {
+  boolean determine(final RuntimeException throwable);
+}

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -224,9 +224,7 @@ public class JedisPool extends JedisPoolAbstract {
 
   @Override
   public Jedis getResource() {
-    Jedis jedis = super.getResource();
-    jedis.setDataSource(this);
-    return jedis;
+    return super.getResource();
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/JedisPoolAbstract.java
+++ b/src/main/java/redis/clients/jedis/JedisPoolAbstract.java
@@ -6,6 +6,7 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import redis.clients.util.Pool;
 
 public class JedisPoolAbstract extends Pool<Jedis> {
+  public ConnectionBrokenDeterminer connBrokenDeterminer;
 
   public JedisPoolAbstract() {
     super();
@@ -13,6 +14,20 @@ public class JedisPoolAbstract extends Pool<Jedis> {
 
   public JedisPoolAbstract(GenericObjectPoolConfig poolConfig, PooledObjectFactory<Jedis> factory) {
     super(poolConfig, factory);
+  }
+
+  public void setConnectionBrokenDeterminer(final ConnectionBrokenDeterminer determiner) {
+    this.connBrokenDeterminer = determiner;
+  }
+
+  @Override
+  public Jedis getResource() {
+    Jedis jedis = super.getResource();
+    jedis.setDataSource(this);
+    if (connBrokenDeterminer != null) {
+      jedis.setConnectionBrokenDeterminer(connBrokenDeterminer);
+    }
+    return jedis;
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -206,7 +206,6 @@ public class JedisSentinelPool extends JedisPoolAbstract {
   public Jedis getResource() {
     while (true) {
       Jedis jedis = super.getResource();
-      jedis.setDataSource(this);
 
       // get a reference because it can change concurrently
       final HostAndPort master = currentHostMaster;

--- a/src/test/java/redis/clients/jedis/tests/ConnectionBrokenDeterminerTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ConnectionBrokenDeterminerTest.java
@@ -1,0 +1,53 @@
+package redis.clients.jedis.tests;
+
+import org.junit.Test;
+import redis.clients.jedis.*;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.tests.commands.JedisCommandTestBase;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ConnectionBrokenDeterminerTest extends JedisCommandTestBase {
+
+  @Test
+  public void testCustomExceptionHandlerShouldMarkConnectionAsBroken() {
+    JedisPool jedisPool = new JedisPool(new JedisPoolConfig(), jedis.getClient().getHost(),
+        jedis.getClient().getPort(), 2000, "foobared");
+
+    ConnectionBrokenDeterminer determiner = new ConnectionBrokenDeterminer();
+    determiner.addPattern(new ConnectionBrokenPattern() {
+      @Override
+      public boolean determine(RuntimeException throwable) {
+        // It covers "Wrong number of args calling Redis command From Lua script"
+        if (throwable instanceof JedisDataException) {
+          JedisDataException e = (JedisDataException) throwable;
+          if (e.getMessage().contains("Wrong number of args")) {
+            return true;
+          }
+        }
+        return false;
+      }
+    });
+
+    jedisPool.setConnectionBrokenDeterminer(determiner);
+    Jedis jedis2 = null;
+
+    try {
+      jedis2 = jedisPool.getResource();
+
+      jedis2.eval("return redis.pcall('hset', 'a', 'b')");
+      fail("Should raise JedisConnectionException");
+    } catch (JedisConnectionException e) {
+      assertNotNull(jedis2);
+      assertTrue(jedis2.getClient().isBroken());
+    } catch (Throwable e) {
+      fail("Should handle certain exception to JedisConnectionException");
+    } finally {
+      jedis2.close();
+      jedisPool.close();
+    }
+  }
+}


### PR DESCRIPTION
Origin PR: https://github.com/xetorthio/jedis/pull/1261

It is an sketched version of custom exception handler for marking connection as broken, as I stated from xetorthio/jedis#1087

I'm focusing on showing how to introduce custom exception handler, so some details could be missing.
We can start improving from this version - rename new interface/classes to have better naming, introduce new package, change the way how to setup custom exception handler, or maybe find another better ways and rewrite it completely.